### PR TITLE
imported issue-refs from nethserver-mock

### DIFF
--- a/nethserver-makerpms.spec
+++ b/nethserver-makerpms.spec
@@ -9,6 +9,7 @@ URL:            http://www.nethserver.org
 Source0:        %{name}-%{version}.tar.gz
 
 Requires: podman
+Requires: python3, python3-requests
 
 %description
 Provides build automation for NethServer packages based on Linux containers

--- a/nethserver-makerpms.spec
+++ b/nethserver-makerpms.spec
@@ -32,6 +32,7 @@ install -vp buildimage/* %{buildroot}/%{_datarootdir}/%{name}
 %{_bindir}/makesrpm
 %{_bindir}/uploadrpms
 %{_bindir}/releasetag
+%{_bindir}/issue-refs
 %{_datarootdir}/%{name}/
 %doc LICENSE
 %doc README.rst

--- a/src/bin/issue-refs
+++ b/src/bin/issue-refs
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 
 #
 # Copyright (C) 2016 Nethesis S.r.l.
@@ -36,7 +36,7 @@ for line in sys.stdin:
     redmine_refs.update(dict.fromkeys(re.findall(redmine_match, line)))
     github_refs.update(dict.fromkeys(re.findall(github_match, line)))
 
-for issue_id in redmine_refs.iterkeys():
+for issue_id in redmine_refs.keys():
     try:
         url = 'http://dev.nethserver.org/issues/%s.json' % issue_id
         response = requests.get(url, headers={'User-Agent': None})
@@ -72,11 +72,11 @@ for issue_org, issue_repo, issue_id in github_refs:
         issue = response.json()
         print("- %s - %s%s/%s#%s%s" % ( \
             issue['title'], \
-            "Bug " if filter(lambda l: l["name"] == "bug", issue["labels"]) else "", \
+            "Bug " if list(filter(lambda l: l["name"] == "bug", issue["labels"])) else "", \
             issue_org,
             issue_repo,
             issue['number'], \
-            "" if filter(lambda l: l["name"] == "verified", issue["labels"]) \
+            "" if list(filter(lambda l: l["name"] == "verified", issue["labels"])) \
                else " !! INCOMPLETE" \
         ))
     except Exception as e:

--- a/src/bin/issue-refs
+++ b/src/bin/issue-refs
@@ -1,0 +1,83 @@
+#!/usr/bin/python
+
+#
+# Copyright (C) 2016 Nethesis S.r.l.
+# http://www.nethesis.it - nethserver@nethesis.it
+#
+# This script is part of NethServer.
+#
+# NethServer is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License,
+# or any later version.
+#
+# NethServer is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with NethServer.  If not, see COPYING.
+#
+
+import sys
+import json
+import requests
+import re
+import os
+
+redmine_refs = {}
+github_refs = {}
+
+github_match = re.compile(ur'\b([^/\s]+)/([^#\s]+)#(\d+)', re.IGNORECASE)
+redmine_match = re.compile(ur'\bRefs\s+#(\d+)', re.IGNORECASE)
+
+for line in sys.stdin:
+    redmine_refs.update(dict.fromkeys(re.findall(redmine_match, line)))
+    github_refs.update(dict.fromkeys(re.findall(github_match, line)))
+
+for issue_id in redmine_refs.iterkeys():
+    try:
+        url = 'http://dev.nethserver.org/issues/%s.json' % issue_id
+        response = requests.get(url, headers={'User-Agent': None})
+        if not response.ok:
+            raise RuntimeError("%s: %s: " % (response.status_code, response.text))
+        issue = response.json()['issue']
+        print "- %s - %s #%s [%s]%s" % ( \
+            issue["subject"], \
+            issue["tracker"]["name"], \
+            issue["id"], \
+            issue["project"]["name"], \
+            "" if issue["status"]["name"] in ["CLOSED", "VERIFIED"] \
+                else " !!%s" % issue["status"]["name"] \
+        )
+    except Exception, e:
+        sys.stderr.write("[ERROR] %s\n" % str(e))
+
+try:
+    if github_refs:
+        with open(os.path.expanduser('~/.release_tag_token')) as tokenf:
+            token = tokenf.readline().rstrip()
+            github_headers = {'Authorization': 'token %s' % token}
+except IOError as e:
+    sys.stderr.write("[ERROR] Failed to read the GitHub API token (%s)\n" % str(e))
+    github_headers = {}
+
+for issue_org, issue_repo, issue_id in github_refs:
+    try:
+        url = 'https://api.github.com/repos/%s/%s/issues/%s' % (issue_org, issue_repo, issue_id)
+        response = requests.get(url, headers=github_headers)
+        if not response.ok:
+            raise RuntimeError("%s: %s: " % (response.status_code, response.text))
+        issue = response.json()
+        print "- %s - %s%s/%s#%s%s" % ( \
+            issue['title'], \
+            "Bug " if filter(lambda l: l["name"] == "bug", issue["labels"]) else "", \
+            issue_org,
+            issue_repo,
+            issue['number'], \
+            "" if filter(lambda l: l["name"] == "verified", issue["labels"]) \
+               else " !! INCOMPLETE" \
+        )
+    except Exception, e:
+        sys.stderr.write("[ERROR] %s\n" % str(e))

--- a/src/bin/issue-refs
+++ b/src/bin/issue-refs
@@ -29,8 +29,8 @@ import os
 redmine_refs = {}
 github_refs = {}
 
-github_match = re.compile(ur'\b([^/\s]+)/([^#\s]+)#(\d+)', re.IGNORECASE)
-redmine_match = re.compile(ur'\bRefs\s+#(\d+)', re.IGNORECASE)
+github_match = re.compile(r'\b([^/\s]+)/([^#\s]+)#(\d+)', re.IGNORECASE)
+redmine_match = re.compile(r'\bRefs\s+#(\d+)', re.IGNORECASE)
 
 for line in sys.stdin:
     redmine_refs.update(dict.fromkeys(re.findall(redmine_match, line)))
@@ -43,15 +43,15 @@ for issue_id in redmine_refs.iterkeys():
         if not response.ok:
             raise RuntimeError("%s: %s: " % (response.status_code, response.text))
         issue = response.json()['issue']
-        print "- %s - %s #%s [%s]%s" % ( \
+        print("- %s - %s #%s [%s]%s" % ( \
             issue["subject"], \
             issue["tracker"]["name"], \
             issue["id"], \
             issue["project"]["name"], \
             "" if issue["status"]["name"] in ["CLOSED", "VERIFIED"] \
                 else " !!%s" % issue["status"]["name"] \
-        )
-    except Exception, e:
+        ))
+    except Exception as e:
         sys.stderr.write("[ERROR] %s\n" % str(e))
 
 try:
@@ -70,7 +70,7 @@ for issue_org, issue_repo, issue_id in github_refs:
         if not response.ok:
             raise RuntimeError("%s: %s: " % (response.status_code, response.text))
         issue = response.json()
-        print "- %s - %s%s/%s#%s%s" % ( \
+        print("- %s - %s%s/%s#%s%s" % ( \
             issue['title'], \
             "Bug " if filter(lambda l: l["name"] == "bug", issue["labels"]) else "", \
             issue_org,
@@ -78,6 +78,6 @@ for issue_org, issue_repo, issue_id in github_refs:
             issue['number'], \
             "" if filter(lambda l: l["name"] == "verified", issue["labels"]) \
                else " !! INCOMPLETE" \
-        )
-    except Exception, e:
+        ))
+    except Exception as e:
         sys.stderr.write("[ERROR] %s\n" % str(e))


### PR DESCRIPTION
Once installed nethserver-makerpms on Fedora 31, using `upload-rpms` script generate an error: issue-refs command not found.

The script belongs to nethserver-mock package, so I've imported it to the current package.