### PR TITLE
cgroup-manager must be set to systemd

### DIFF
--- a/src/bin/makerpms
+++ b/src/bin/makerpms
@@ -74,6 +74,7 @@ fi
 
 podman run \
     --hostname b$$.$(hostname) \
+    --cgroup-manager=systemd \
     --name "${container_id}" \
     --security-opt label=disable \
     --volume $PWD:/srv/makerpms/src:ro \


### PR DESCRIPTION
https://github.com/NethServer/dev/issues/6132


we have two options for cgroup-manager 

cgroupfs   -> fails
systemd - > the build succeed 

```
  --cgroup-manager=manager

       CGroup  manager to use for container cgroups. Supported values are cgroupfs or systemd. Default is systemd unless overrid‐
       den in the libpod.conf file.

       Note: Setting this flag can cause certain commands to break when called on containers  previously  created  by  the  other
       CGroup manager type.  Note: CGroup manager is not supported in rootless mode when using CGroups Version V1.
```
