### PR TITLE
New command line interface

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,3 +30,4 @@ env:
 
 script:
     - bash -x travis/build-container.sh
+    - bash -x travis/build-rpms.sh

--- a/README.rst
+++ b/README.rst
@@ -59,6 +59,11 @@ It is possible to override the builder command, with the ``COMMAND`` environment
   $ COMMAND="whoami" makerpms *.spec
   makerpms
 
+Additional arguments can be passed to YUM before starting the binary build, to fetch dependencies
+not tracked by ``BuildRequires``, enable additional repositories and so on... ::
+
+  $ YUM_ARGS="--enablerepo=nethserver-testing" makerpms *.spec
+
 
 Optimizations
 -------------

--- a/README.rst
+++ b/README.rst
@@ -18,9 +18,9 @@ you must be root to make it work on NethServer 7.
 Installation
 ------------
 
-On Fedora 29+ ::
+On Fedora 31+ ::
 
-  $ sudo dnf install http://packages.nethserver.org/nethserver/7.6.1810/updates/x86_64/Packages/nethserver-makerpms-1.0.0-1.ns7.noarch.rpm
+  $ sudo dnf install http://packages.nethserver.org/nethserver/7.8.2003/updates/x86_64/Packages/nethserver-makerpms-1.2.0-1.ns7.noarch.rpm
 
 On NethServer 7 ::
 
@@ -44,11 +44,21 @@ during the build.
 
 If the requirements are met, change directory to the repository root then run ::
 
-  makerpms *.spec
+  $ makerpms *.spec
 
 To build a NethServer 6 RPM pass the ``NSVER`` environment variable to ``makerpms`` ::
 
-  NSVER=6 makerpms *.spec
+  $ NSVER=6 makerpms *.spec
+
+If you have a custom or development builder image to test, set the ``IMAGE`` environment variable, e.g.: ::
+
+  $ IMAGE=me/myimage:test makerpms *.spec
+
+It is possible to override the builder command, with the ``COMMAND`` environment variable ::
+
+  $ COMMAND="whoami" makerpms *.spec
+  makerpms
+
 
 Optimizations
 -------------
@@ -58,7 +68,7 @@ Container instances share the named Podman volume ``makerpms-yum-cache``.
 
 To clear the YUM cache run ::
 
-    podman volume rm makerpms-yum-cache
+  $ podman volume rm makerpms-yum-cache
 
 
 Container images
@@ -69,6 +79,10 @@ https://hub.docker.com/r/nethserver/makerpms.
 
 * ``nethserver/makerpms:7`` is the default image, for ``noarch`` builds
 * ``nethserver/makerpms:buildsys7`` is the image for ``x86_64`` builds
+* ``nethserver/makerpms:devtoolset7`` is the image for ``x86_64`` builds 
+  with GCC 9 (devtoolset-9 from SCLo), then run makerpms in a SCLo environment, e.g. : ::
+
+    $ COMMAND="scl enable devtoolset-9 -- makerpms" makerpms *.spec
 
 To build the image locally run ::
 

--- a/buildimage/makerpms
+++ b/buildimage/makerpms
@@ -36,6 +36,9 @@ if [[ ${topdir}/SRPMS/*.src.rpm == "${topdir}/SRPMS/*.src.rpm" ]]; then
     fi
 fi
 
+# Skip the .spec file argument
+shift
+
 echo '[INFO] Installing build deps...'
 PATH=/usr/bin sudo yum install -y --setopt=tsflags=nodocs ${YUM_ARGS} $(rpm -qp --requires ${topdir}/SRPMS/*.src.rpm)
 

--- a/buildimage/makerpms
+++ b/buildimage/makerpms
@@ -20,6 +20,12 @@
 # along with NethServer.  If not, see COPYING.
 #
 
+# Sanitize arguments with new call style
+if [[ $1 == "-s" ]]; then
+    echo "[WARNING] the -s flag is no more required. Use '$0 filename.spec [arg]...' instead." 1>&2
+    shift
+fi
+
 topdir=$(rpm --eval '%_topdir')
 
 # Run makesrpm first, if src RPM is not available:
@@ -30,22 +36,8 @@ if [[ ${topdir}/SRPMS/*.src.rpm == "${topdir}/SRPMS/*.src.rpm" ]]; then
     fi
 fi
 
-# Ignore arguments for makesrpm
-while getopts ":s:c:" opt; do
-    case $opt in
-    s)
-        ;;
-    c)
-        ;;
-    *)
-        break
-        ;;
-    esac
-done
-shift $((OPTIND-1))
-
 echo '[INFO] Installing build deps...'
-PATH=/usr/bin sudo yum install -y --setopt=tsflags=nodocs $(rpm -qp --requires ${topdir}/SRPMS/*.src.rpm)
+PATH=/usr/bin sudo yum install -y --setopt=tsflags=nodocs ${YUM_ARGS} $(rpm -qp --requires ${topdir}/SRPMS/*.src.rpm)
 
 echo '[INFO] Rebuild ' ${topdir}/SRPMS/*.src.rpm
 exec rpmbuild -D "dist ${DIST:-.ns7}" --rebuild ${topdir}/SRPMS/*.src.rpm "$@"

--- a/buildimage/makerpms
+++ b/buildimage/makerpms
@@ -22,7 +22,6 @@
 
 # Sanitize arguments with new call style
 if [[ $1 == "-s" ]]; then
-    echo "[WARNING] the -s flag is no more required. Use '$0 filename.spec [arg]...' instead." 1>&2
     shift
 fi
 

--- a/buildimage/makesrpm
+++ b/buildimage/makesrpm
@@ -24,7 +24,6 @@ set -e
 
 # Sanitize arguments with new call style
 if [[ $1 == "-s" ]]; then
-    echo "[WARNING] the -s flag is no more required. Use '$0 filename.spec [arg]...' instead." 1>&2
     shift
 fi
 specfile=${1:?"Bad invocation. Use '$0 filename.spec [arg]...' instead."}

--- a/buildimage/makesrpm
+++ b/buildimage/makesrpm
@@ -22,35 +22,12 @@
 
 set -e
 
-function exit_error {
-   echo $1 >&2
-   exit 1
-}
-
-function help {
-   echo "Usage: $0 -s input.spec [-c commit]" >&2
-   echo '
-             -s input.spec         : The input RPM .spec file
-             -c commit             : the commit tag for development version build
-' >&2
-}
-
-while getopts ":s:c:" opt; do
-    case $opt in
-    s)
-        specfile=$OPTARG
-        [ -z "${specfile}" ] && exit_error "No spec file given"
-        ;;
-    c)
-        commit=$OPTARG
-        [ -z "${commit}" ] && exit_error "No commit given"
-        ;;
-    *)
-        break
-        ;;
-    esac
-done
-shift $((OPTIND-1))
+# Sanitize arguments with new call style
+if [[ $1 == "-s" ]]; then
+    echo "[WARNING] the -s flag is no more required. Use '$0 filename.spec [arg]...' instead." 1>&2
+    shift
+fi
+specfile=${1:?"Bad invocation. Use '$0 filename.spec [arg]...' instead."}
 
 topdir=$(rpm --eval '%_topdir')
 

--- a/src/bin/makerpms
+++ b/src/bin/makerpms
@@ -36,13 +36,16 @@ if [ -z "$1" ]; then
     echo "    " $(basename $0) "filename.spec [args]..."
     echo ""
     echo "Sensible to the following environment variables:"
-    echo " - NSVER (${NSVER}) # NethServer version"
-    echo " - DIST (${DIST}) # Package DIST suffix"
+    echo " - NSVER (${NSVER})   # NethServer version"
+    echo " - DIST (${DIST})     # Package DIST suffix"
+    echo " - IMAGE (${IMAGE})   # Override the builder image"
     echo ""
     exit 1
 fi
 
-if grep -q -E 'BuildArch:\s*noarch' "${1}"; then
+if [[ -n "${IMAGE}" ]]; then
+    image="${IMAGE}"
+elif grep -q -E 'BuildArch:\s*noarch' "${1}"; then
     image=nethserver/makerpms:${NSVER}
 else
     image=nethserver/makerpms:buildsys${NSVER}
@@ -83,8 +86,13 @@ podman run \
     --tty \
     --interactive \
     ${image} \
-    ${command:-makerpms -s} "${@}"
+    ${command:-makerpms} "${@}"
 
 sync
 podman export "${container_id}" | tar -x -v --xform='s#^.+/##x' -f - srv/makerpms/rpmbuild/{S,}RPMS
-podman rm "${container_id}"
+
+if [[ "${command}" == "makerpms" || "${command}" == "makesrpm" ]]; then
+    podman rm "${container_id}"
+else
+    echo "[WARNING] the container has not been removed. Run 'podman rm ${container_id}' to drop it."
+fi

--- a/src/bin/makerpms
+++ b/src/bin/makerpms
@@ -22,7 +22,7 @@
 
 set -e
 
-export NSVER=${NSVER:-7} DIST
+export NSVER=${NSVER:-7} DIST COMMAND=${COMMAND:-makerpms}
 
 if [[ -z ${DIST} ]]; then
     DIST=.ns${NSVER}
@@ -36,9 +36,10 @@ if [ -z "$1" ]; then
     echo "    " $(basename $0) "filename.spec [args]..."
     echo ""
     echo "Sensible to the following environment variables:"
-    echo " - NSVER (${NSVER})   # NethServer version"
-    echo " - DIST (${DIST})     # Package DIST suffix"
-    echo " - IMAGE (${IMAGE})   # Override the builder image"
+    echo " - NSVER (${NSVER}) # NethServer version"
+    echo " - DIST (${DIST}) # Package DIST suffix"
+    echo " - IMAGE # Override the builder image"
+    echo " - COMMAND (${COMMAND:-makerpms}) # Override the builder command"
     echo ""
     exit 1
 fi
@@ -86,12 +87,12 @@ podman run \
     --tty \
     --interactive \
     ${image} \
-    ${command:-makerpms} "${@}"
+    ${COMMAND} "${@}"
 
 sync
 podman export "${container_id}" | tar -x -v --xform='s#^.+/##x' -f - srv/makerpms/rpmbuild/{S,}RPMS
 
-if [[ "${command}" == "makerpms" || "${command}" == "makesrpm" ]]; then
+if [[ "${COMMAND}" == "makerpms" || "${COMMAND}" == "makesrpm" ]]; then
     podman rm "${container_id}"
 else
     echo "[WARNING] the container has not been removed. Run 'podman rm ${container_id}' to drop it."

--- a/src/bin/makerpms
+++ b/src/bin/makerpms
@@ -22,7 +22,7 @@
 
 set -e
 
-export NSVER=${NSVER:-7} DIST COMMAND=${COMMAND:-makerpms}
+export NSVER=${NSVER:-7} DIST COMMAND=${COMMAND:-makerpms} YUM_ARGS
 
 if [[ -z ${DIST} ]]; then
     DIST=.ns${NSVER}
@@ -40,6 +40,7 @@ if [ -z "$1" ]; then
     echo " - DIST (${DIST}) # Package DIST suffix"
     echo " - IMAGE # Override the builder image"
     echo " - COMMAND (${COMMAND:-makerpms}) # Override the builder command"
+    echo " - YUM_ARGS # Extra arguments for YUM, to set up the packages in the builder image"
     echo ""
     exit 1
 fi
@@ -84,6 +85,7 @@ podman run \
     --volume ${cachevol}:/var/cache/yum \
     --env NSVER \
     --env DIST \
+    --env YUM_ARGS \
     --tty \
     --interactive \
     ${image} \

--- a/src/bin/makesrpm
+++ b/src/bin/makesrpm
@@ -20,5 +20,5 @@
 # along with NethServer.  If not, see COPYING.
 #
 
-export command="makesrpm -s"
+export command="makesrpm"
 exec makerpms "${@}"

--- a/src/bin/makesrpm
+++ b/src/bin/makesrpm
@@ -20,5 +20,5 @@
 # along with NethServer.  If not, see COPYING.
 #
 
-export command="makesrpm"
+export COMMAND="makesrpm"
 exec makerpms "${@}"

--- a/travis/build-rpms.sh
+++ b/travis/build-rpms.sh
@@ -3,7 +3,7 @@ set -e
 docker run -ti --name makerpms ${EVARS} \
     --hostname b${TRAVIS_BUILD_NUMBER}.nethserver.org \
     --volume $PWD:/srv/makerpms/src:ro ${DOCKER_IMAGE} \
-    makerpms-travis -s *.spec
+    makerpms-travis *.spec
 
 docker commit makerpms nethserver/build
 


### PR DESCRIPTION
The builder commands has -s and -c switches (almost useless). Let's drop them.

New invocation syntax is

    makerpms filename.spec [arg]...

Extra arguments are passed to rpmbuild: useful for binary packages build.

Also to ease the development of customizations:

- the makesrpm builder script is sensible to YUM_ARGS environment variable: useful to enable additional repositories and download extra build dependencies
- the makerpms podman helper script is sensible to the IMAGE environment variable: useful to override the builder image and use a local one (for development?) 
- it is possible to pass more arguments (e.g. to define rpmbuild macros)
- the actual COMMAND is fully customizable (e.g. to run rpmbuild in a SCL environment)

https://github.com/nethesis/dev/issues/5836