### PR TITLE
Fixes for releasetag command

### DIFF
--- a/src/bin/releasetag
+++ b/src/bin/releasetag
@@ -35,21 +35,21 @@ git_tag_opts=
 
 while getopts "t:T:k:h" opt; do
     case $opt in
-	h)
-	    exit_help
-	    ;;
+    h)
+        exit_help
+        ;;
         k)  # gpg sign git tag
             git_tag_opts+="-s -u $OPTARG"
-	    ;;
-	T)  # Add rpm makefile variable definition
-	    tag="$OPTARG"
-	    ;;
-	t)  # Alias for T
-	    tag="$OPTARG"
-	    ;;
-	\?) # Print help message and exit
-	    exit_help
-	    ;;
+        ;;
+    T)  # Add rpm makefile variable definition
+        tag="$OPTARG"
+        ;;
+    t)  # Alias for T
+        tag="$OPTARG"
+        ;;
+    \?) # Print help message and exit
+        exit_help
+        ;;
     esac
 done
 

--- a/src/bin/releasetag
+++ b/src/bin/releasetag
@@ -33,7 +33,7 @@ function exit_help ()
 
 git_tag_opts=
 
-while getopts "T:k:h" opt; do
+while getopts "t:T:k:h" opt; do
     case $opt in
 	h)
 	    exit_help
@@ -42,6 +42,9 @@ while getopts "T:k:h" opt; do
             git_tag_opts+="-s -u $OPTARG"
 	    ;;
 	T)  # Add rpm makefile variable definition
+	    tag="$OPTARG"
+	    ;;
+	t)  # Alias for T
 	    tag="$OPTARG"
 	    ;;
 	\?) # Print help message and exit

--- a/src/bin/releasetag
+++ b/src/bin/releasetag
@@ -22,7 +22,6 @@
 
 set -e
 
-issuetracker_url=${issuetracker_url:-http://dev.nethserver.org}
 export LANG=C
 unset ${!LC_*}
 

--- a/src/bin/releasetag
+++ b/src/bin/releasetag
@@ -27,7 +27,7 @@ unset ${!LC_*}
 
 function exit_help ()
 {
-   echo "Usage: $(basename $0) [-h] [-k KEYID] [-T <x.y.z>] [<file>.spec]" 1>&2
+   echo "Usage: $(basename $0) [-h] [-k KEYID] [-T <x.y.z>] <file>.spec" 1>&2
    exit 1
 }
 
@@ -56,6 +56,12 @@ done
 # Eat all the options:
 shift $(($OPTIND - 1)) || exit_help
 
+spec_file="$1"
+
+if [[ -z "${spec_file} "]]; then
+    exit_help
+fi
+
 if [ -z "${tag}" ]; then
     SHOW_ONLY="1"
 fi
@@ -65,8 +71,6 @@ git_user_name=$(git config --get user.name)
 git_user_email=$(git config --get user.email)
 editor=${EDITOR:-$(git config --get core.editor || echo 'vi')}
 changelog_timestamp=$(date +"%a %b %d %Y")
-spec_file=(*.spec)
-spec_file=${1:-${spec_file[0]}}
 
 gitdesc=($(git describe --tags --match "[0-9]*" --abbrev=7 HEAD 2>/dev/null | tr '-' ' '))
 last_release=


### PR DESCRIPTION
- Mandatory file.spec argument
- Add the -t alias flag for -T
- Code cleanup

Thanks to @gsanchietti 