### PR TITLE
Fix old images default usage

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -92,11 +92,11 @@ Builder container images
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
 The builder container images are updated periodically and are available at
-https://hub.docker.com/r/nethserver/makerpms.
+https://github.com/nethserver/nethserver-makerpms/pkgs/container/makerpms.
 
-* ``nethserver/makerpms:7`` is the default image, for ``noarch`` builds
-* ``nethserver/makerpms:buildsys7`` is the image for ``x86_64`` builds (GCC 4)
-* ``nethserver/makerpms:devtoolset7`` is the image for ``x86_64`` builds
+* ``ghcr.io/nethserver/makerpms:7`` is the default image, for ``noarch`` builds
+* ``ghcr.io/nethserver/makerpms:buildsys7`` is the image for ``x86_64`` builds (GCC 4)
+* ``ghcr.io/nethserver/makerpms:devtoolset7`` is the image for ``x86_64`` builds
   with GCC 9 (devtoolset-9 from SCLo), then run makerpms in a SCLo environment, e.g. : ::
 
     $ COMMAND="scl enable devtoolset-9 -- makerpms" makerpms *.spec

--- a/build.sh
+++ b/build.sh
@@ -16,7 +16,7 @@ function build_image()
         container
 }
 
-image=${IMAGE_REPO:-nethserver/makerpms}
+image=${IMAGE_REPO:-ghcr.io/nethserver/makerpms}
 if ! command -v buildah &> /dev/null; then
     echo "buildah could not be found, is needed for the script to run."
     exit 1

--- a/src/bin/makerpms
+++ b/src/bin/makerpms
@@ -48,9 +48,9 @@ fi
 if [[ -n "${IMAGE}" ]]; then
     image="${IMAGE}"
 elif grep -q -E 'BuildArch:\s*noarch' "${1}"; then
-    image=nethserver/makerpms:${NSVER}
+    image=ghcr.io/nethserver/makerpms:${NSVER}
 else
-    image=nethserver/makerpms:buildsys${NSVER}
+    image=ghcr.io/nethserver/makerpms:buildsys${NSVER}
 fi
 
 IFS=- read desc_tag desc_commitn desc_commith <<<$(git describe --tags --match "[0-9]*" --abbrev=7 HEAD 2>/dev/null)


### PR DESCRIPTION
Use fully specified image names instead of short names. Otherwise, the old images in docker.io will be used instead of the updated ones on ghcr.io.
