### PR TITLE
fix: yum, use only NethServer.repo

### DIFF
--- a/container/Containerfile
+++ b/container/Containerfile
@@ -1,11 +1,16 @@
 FROM centos:7 as makerpms
-RUN sed -i -e '/^mirrorlist=http:\/\/mirrorlist.centos.org\// { s/^/#/ ; T }' \
-           -e '{ s/#baseurl=/baseurl=/ ; s/mirror\.centos\.org/vault.centos.org/ ; s/\$releasever/7.9.2009/ }' \
-           /etc/yum.repos.d/CentOS-*.repo \
-    && yum -y install \
-        http://packages.nethserver.org/nethserver/nethserver-release-7.rpm \
+# Enable only repositories from NethServer.repo
+RUN rm -f /etc/yum.repos.d/*
+RUN yum -y install \
+        http://packages.nethserver.org/nethserver/nethserver-release-7.rpm
+RUN sed -i 's/enabled=0/enabled=1/g' /etc/yum.repos.d/NethServer.repo
+RUN yum -y install \
         centos-release-scl \
-        epel-release \
+        epel-release
+# Delete all .repo except NethServer.repo
+RUN find /etc/yum.repos.d/ -type f ! -name 'NethServer.repo' -delete
+RUN rpm --import /etc/pki/rpm-gpg/* || true
+RUN yum -y install \
         expect \
         git \
         nethserver-devtools \
@@ -16,10 +21,7 @@ RUN sed -i -e '/^mirrorlist=http:\/\/mirrorlist.centos.org\// { s/^/#/ ; T }' \
         sudo \
         yum-utils \
     && yum clean all \
-    && rm -rf /var/cache/yum/* \
-    && sed -r -i -e '/^# ?baseurl=http:\/\/mirror.centos.org/ { s/# ?// ; s/mirror/vault/ }' \
-           -e '/^mirrorlist=http:\/\/mirrorlist.centos.org\?/ s/^/#/' \
-           /etc/yum.repos.d/CentOS-SCLo*.repo
+    && rm -rf /var/cache/yum/*
 
 COPY bin /usr/local/bin
 COPY sudoers.d /etc/sudoers.d


### PR DESCRIPTION
All CentOS services for EPEL 7 have been dismissed: the build was failing because mirrorlist.centos.org was not accessible